### PR TITLE
Add extra attribute to validate action so users can input extra commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,45 +1,71 @@
 
 # Action Validate Image
 
-"Validate" is a custom GitHub Action made by Enterprise Contract that validates container images for security and compliance. It performs a three-stage validation process:
+"Validate" is a robust GitHub Action developed by Enterprise Contract, designed to assess container images for security and compliance. This action has two authentication methods: Long-Lived Public-Key Authentication and Keyless Authentication made possible by Enterprise Contract.
+## Keyless Authentication: The Strongest Approach
 
-1. **Signature Verification:** Checks if the image is signed and verifies the signature with a provided public key.
+Keyless Authentication represts the highest level of Sigstore sophistication. Verification revolves around the signer's identity, It's made possible by  two essential parts:
 
-2. **Attestation Verification:** Ensures the image has signed and valid attestations, providing additional information about its source.
+- **Certificate Identity:** This identifier is crucial for verifying the image-associated certificate.
+- **Certificate OIDC Issuer:** The OIDC issuer serves a vital role in validating the identity.
 
-3. **Policy Conformance Verification:** Verifies that the image's attestations comply with defined policies, ensuring adherence to organizational standards.
+Keyless Authentication significantly enhances security, ensuring image authenticity. The verification process hinges on the signer's identity, providing an innovative solution for robust container image authentication.
 
-* [Read more](https://enterprisecontract.dev/docs/ec-cli/main/ec_validate_image.html#_synopsis) 
-* [Read more](https://redhat-appstudio.github.io/book/book/enterprise-contract.html#:~:text=EC%20CLI,or%20violations%20produced)
+## Long-Lived Public-Key Authentication
+
+The Long-Lived Public-Key Authentication method involves a comprehensive three-stage validation process:
+
+1. **Signature Verification:** The action meticulously checks image signatures and validates them using designated public keys.
+
+2. **Attestation Verification:** It ensures images possess valid and signed attestations, enriching details about image origin and attributes.
+
+3. **Policy Conformance Verification:** This step aligns image attestations with pre-established policies, guaranteeing organizational standards compliance.
+
+For more details:
+
+- [Enterprise Contract Documentation](https://enterprisecontract.dev/docs/ec-cli/main/ec_validate_image.html#_synopsis)
+- [Red Hat AppStudio Documentation](https://redhat-appstudio.github.io/book/book/enterprise-contract.html#:~:text=EC%20CLI,or%20violations%20produced)
 
 
+## Environment Variables 
 
-## Environment Variables
+To use this action, please configure the following environment variables in your workflow based on the desired authentication method.
 
-To run this action, you will need to add the following variables to your workflow.
+### Using Long-Lived Public-Key Authentication
+
+The Long-Lived public-key method offers a straightforward way to integrate with Sigstore. Below are the variables needed:
+
 | Name          | Description                                                                                      | Example                                     |
 |---------------|--------------------------------------------------------------------------------------------------|---------------------------------------------|
-| Public Key    | The public key for verifying signatures.                                                | `"your_public_key_goes_here"`                 |
-| Policy        | The location of the policy.yaml config file to be used when running Enterprise Contract. A list of standard configs can be found at [here](https://github.com/enterprise-contract/config).  | `"github.com/enterprise-contract/config//slsa3"` |
-| Image         | Image that is built.                                                                            | `"quay.io/redhat-appstudio/ec-golden-image:latest"` |
+| Public Key    | The public key for verifying signatures.                                                | `your_public_key_goes_here`                 |
+| Policy        | The location of the policy.yaml config file to be used when running Enterprise Contract. A list of standard configs can be found at [here](https://github.com/enterprise-contract/config).  | `github.com/enterprise-contract/config//slsa3` |
+| Image         | Image that is built.                                                                            | `quay.io/redhat-appstudio/ec-golden-image:latest` |
 
+### Using Identity-Based Short-Lived (Keyless) Authentication
 
+This authentication approach is the most robust, as Sigstore authentication is based on the signer's identity rather than a key. The following variables are needed:
+
+| Name          | Description                                                                                      | Example                                     |
+|---------------|--------------------------------------------------------------------------------------------------|---------------------------------------------|
+| Identity      | Identity to verify the certificate linked to the image.                                          | `https:\/\/github\.com\/(slsa-framework\/slsa-github-generator\|lcarva\/festoji)\/`                 |
+| Issuer        | OIDC issuer for validation purposes.                                                             | `https://token.actions.githubusercontent.com` |
+| Image         | Image to be built.                                                                               | `quay.io/lucarval/festoji:latest` |
+
+Ensure to pick the right method for your needs and set up the variables accordingly.
 
 ## Usage/Examples
 
-If you're eager to experience the benefits of the "Validate" action in your build process, follow these simple steps to get started. By copying and pasting the example below to your project's `.github/workflows/` directory, you'll be on your way to enhancing your container image security and compliance.
+If you're eager to experience the benefits of the "Validate" action in your build process, follow these simple steps to get started. By copying and pasting either 'keyless' or  'long-lived' example below to your project's `.github/workflows/` directory, you'll be on your way to enhancing your container image security and compliance.
+
+### Long-Lived Public-Key Authentication Example
 
 **Copy and Paste:** Insert the example snippet below into your `.github/workflows/` directory.
-
-**Customize Your Parameters:** Tailor the example to your specific needs:
 1. Replace the Image with your image URL or file path within the `image` parameter.
 2. Set up your key using GitHub vars, following recommended practices. Tutorial can be found [here](https://docs.github.com/en/actions/learn-github-actions/variables#creating-configuration-variables-for-a-repository)
 3. Choose a policy that aligns with your requirements and objectives. Policy's can be found [here](https://github.com/enterprise-contract/config)
-
-You are now ready to run the validate action.
-
+Public-Key Authentication)
 ```javascript
-name: example of action validate image
+name: example of action validate using long-lived
 on:
   push:
     branches:
@@ -51,8 +77,34 @@ jobs:
 
     steps:
     - name: Run EC Validator
-      uses: enterprise-contract/action-validate-image@v1
+      uses: enterprise-contract/action-validate-image@v1.1
       with:
         image: "quay.io/redhat-appstudio/ec-golden-image:latest"
         key: ${{ vars.PUBLIC_KEY }}
         policy: "github.com/enterprise-contract/config//default"
+```
+
+### Identity-Based Short-Lived (Keyless) Example
+**Copy and Paste:** Insert the example snippet below into your `.github/workflows/` directory.
+1. Replace the Image with your image URL or file path within the `image` parameter.
+2. Provide your certificate's identity.
+3. Add your certificate's OIDC issuer details.
+```javascript
+name: example of action validate using keyless
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Run EC Validator
+      uses: enterprise-contract/action-validate-image@v1.1
+      with:
+        image: quay.io/lucarval/festoji:latest
+        identity: https:\/\/github\.com\/(slsa-framework\/slsa-github-generator|lcarva\/festoji)\/
+        issuer: https://token.actions.githubusercontent.com
+```

--- a/README.md
+++ b/README.md
@@ -53,6 +53,13 @@ This authentication approach is the most robust, as Sigstore authentication is b
 
 Ensure to pick the right method for your needs and set up the variables accordingly.
 
+### Optional
+The Enterprise Contract provides a variety of additional commands that can seamlessly integrate into this action. These commands are outlined in the official documentation, which can be found [here](https://enterprisecontract.dev/docs/ec-cli/main/ec_validate_image.html#_options). You have the freedom to incorporate multiple commands as needed. Just simple add `command` into your worflow 
+
+```shell
+command: --ignore-rekor --debug
+```
+
 ## Usage/Examples
 
 If you're eager to experience the benefits of the "Validate" action in your build process, follow these simple steps to get started. By copying and pasting either 'keyless' or  'long-lived' example below to your project's `.github/workflows/` directory, you'll be on your way to enhancing your container image security and compliance.
@@ -82,6 +89,7 @@ jobs:
         image: "quay.io/redhat-appstudio/ec-golden-image:latest"
         key: ${{ vars.PUBLIC_KEY }}
         policy: "github.com/enterprise-contract/config//default"
+        command: --ignore-rekor
 ```
 
 ### Identity-Based Short-Lived (Keyless) Example

--- a/action.yaml
+++ b/action.yaml
@@ -3,16 +3,10 @@ description: To run ec against a particular container image built by RHTAP
 
 inputs:
 
-  option:
-    description: Choose either 'keyless' or 'long-lived' validation mode
-    required: true
-    enum:
-      - keyless
-      - long-lived
 
   image:
     description: The image reference
-    required: true
+    required: truequay.io/redhat-appstudio/ec-golden-image:latest
 
   key:
     description: The public key for verifying signatures
@@ -20,7 +14,7 @@ inputs:
 
   policy:
     description: A policy configuration file which determines what policies are to be applied
-    default: github.com/enterprise-contract/config//default
+    required: false
 
   identity:
     description: The identity used to validate the certificate associated with the image
@@ -36,21 +30,14 @@ runs:
 
   steps:
 
-    - name: Run EC validator 
-      if: ${{ inputs.option == 'long-lived' }}
-      uses: docker://quay.io/hacbs-contract/ec-cli:snapshot
-      with:
-        args: |
-          validate image --image "${{ inputs.image }}" --public-key "${{ inputs.key }}" --policy "${{ inputs.policy }}"  --output yaml
-
-    - name: Run EC Validate (keyless)
-      if: ${{ inputs.option == 'keyless' }}
+    - name: Run EC Validate 
       uses: docker://quay.io/hacbs-contract/ec-cli:snapshot
       with:
         args: >
           validate image 
-          --policy ""
+          --policy "${{ inputs.policy }}"
           --image "${{ inputs.image }}"
+          --public-key "${{ inputs.key }}"
           --certificate-identity-regexp="${{ inputs.identity }}"
           --certificate-oidc-issuer="${{ inputs.issuer }}"
           --output yaml 

--- a/action.yaml
+++ b/action.yaml
@@ -24,6 +24,10 @@ inputs:
     description: The OIDC issuer for validation
     required: false
 
+  command:
+    description: A ec command to add to your validate action.
+    required: false
+
   
 runs:
   using: composite
@@ -40,4 +44,5 @@ runs:
           --public-key "${{ inputs.key }}"
           --certificate-identity-regexp="${{ inputs.identity }}"
           --certificate-oidc-issuer="${{ inputs.issuer }}"
+          "${{ inputs.command }}"
           --output yaml 

--- a/action.yaml
+++ b/action.yaml
@@ -2,25 +2,55 @@ name: 'EC-validator'
 description: To run ec against a particular container image built by RHTAP
 
 inputs:
+
+  option:
+    description: Choose either 'keyless' or 'long-lived' validation mode
+    required: true
+    enum:
+      - keyless
+      - long-lived
+
   image:
     description: The image reference
     required: true
 
   key:
     description: The public key for verifying signatures
-    required: true
+    required: false
 
   policy:
     description: A policy configuration file which determines what policies are to be applied
     default: github.com/enterprise-contract/config//default
 
+  identity:
+    description: The identity used to validate the certificate associated with the image
+    required: false
+
+  issuer:
+    description: The OIDC issuer for validation
+    required: false
+
+  
 runs:
   using: composite
 
   steps:
 
-    - name: Run EC validator
+    - name: Run EC validator 
+      if: ${{ inputs.option == 'long-lived' }}
       uses: docker://quay.io/hacbs-contract/ec-cli:snapshot
       with:
         args: |
           validate image --image "${{ inputs.image }}" --public-key "${{ inputs.key }}" --policy "${{ inputs.policy }}"  --output yaml
+
+    - name: Run EC Validate (keyless)
+      if: ${{ inputs.option == 'keyless' }}
+      uses: docker://quay.io/hacbs-contract/ec-cli:snapshot
+      with:
+        args: >
+          validate image 
+          --policy ""
+          --image "${{ inputs.image }}"
+          --certificate-identity-regexp="${{ inputs.identity }}"
+          --certificate-oidc-issuer="${{ inputs.issuer }}"
+          --output yaml 

--- a/action.yaml
+++ b/action.yaml
@@ -44,5 +44,5 @@ runs:
           --public-key "${{ inputs.key }}"
           --certificate-identity-regexp="${{ inputs.identity }}"
           --certificate-oidc-issuer="${{ inputs.issuer }}"
-          "${{ inputs.command }}"
+          ${{ inputs.command }}
           --output yaml 

--- a/action.yaml
+++ b/action.yaml
@@ -6,7 +6,7 @@ inputs:
 
   image:
     description: The image reference
-    required: truequay.io/redhat-appstudio/ec-golden-image:latest
+    required: true
 
   key:
     description: The public key for verifying signatures


### PR DESCRIPTION
Users can now add extra input commands to action-validate-image 
jira: [link](https://issues.redhat.com/browse/HACBS-2518)